### PR TITLE
Adapt constructors to PHP8

### DIFF
--- a/src/class.element.php
+++ b/src/class.element.php
@@ -51,7 +51,7 @@ class CElement
     var $indent     = 0;
 
     // Constructor
-    function CElement( $id = 0, $parent = 0, $content = NULL, $level = 0, $type = ETYPE_LEAF )
+    function __construct( $id = 0, $parent = 0, $content = NULL, $level = 0, $type = ETYPE_LEAF )
     {
         $this->id       = $id;
         $this->parent   = $parent;

--- a/src/class.stringparser.php
+++ b/src/class.stringparser.php
@@ -31,7 +31,7 @@ class CStringParser
     // PUBLIC FUNCTIONS
     // ----------------------------------------------------------------------
 
-    function CStringParser( $s )
+    function __construct( $s )
     {
         // Clean up the data a little to make processing easier
         

--- a/src/class.svggraph.php
+++ b/src/class.svggraph.php
@@ -39,7 +39,7 @@ class CSVGGraph
     // ----------------------------------------------------------------------
     
     // Constructor
-    function CSVGGraph( 
+    function __construct(
          &$e_list_ref
         , $color=TRUE, $antialias=TRUE, $triangles=TRUE
         , $font="Vera.ttf", $fontsize=10 )

--- a/src/class.treegraph.php
+++ b/src/class.treegraph.php
@@ -39,7 +39,7 @@ class CTreeGraph
     // ----------------------------------------------------------------------
     
     // Constructor
-    function CTreeGraph( 
+    function __construct(
          &$e_list_ref
         , $color=TRUE, $antialias=TRUE, $triangles=TRUE
         , $font="FreeSerif.ttf", $fontsize=8 )


### PR DESCRIPTION
After PHP8, constructors with the class name are no longer accepted, so `__construct()` must be used.